### PR TITLE
Fix ws errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,9 +10,9 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.1
-Suggests: 
+Suggests:
     knitr,
     rmarkdown
 VignetteBuilder: knitr
-Depends: 
+Depends:
     R (>= 2.10)

--- a/R/generics.R
+++ b/R/generics.R
@@ -19,7 +19,7 @@ summary.OaxacaBlinderDecomp <- function(x) {
   cat("\n\nDescriptives\n")
   n_tbl = table(x$meta$data[[group_var]])
   pct_tbl = sprintf("%.1f%%", 100*n_tbl / sum(n_tbl))
-  npct_df = setNames(data.frame(n_tbl, pct_tbl),  c("group", "n", "%n")) 
+  npct_df = setNames(data.frame(n_tbl, pct_tbl),  c("group", "n", "%n"))
   rownames(npct_df) = as.character(npct_df$group)
   npct_df$group = NULL
   npct_df = npct_df[as.character(c(group1, group2)), ]
@@ -29,7 +29,7 @@ summary.OaxacaBlinderDecomp <- function(x) {
   )
   rownames(npct_df) = paste(group_var, "==", rownames(npct_df), sep="")
   print(npct_df)
-  
+
   cat("\nGap:", round(x$gaps$gap, digits = 2))
   cat("\n% Diff:", sprintf("%.2f%%", 100 * x$gaps$pct_gap))
   cat("\n")
@@ -51,7 +51,7 @@ summary.OaxacaBlinderDecomp <- function(x) {
 #' @export
 coef.OaxacaBlinderDecomp <- function(x, ci = FALSE) {
   estimates = x$varlevel
-  
+
   if (ci && !is.null(x$bootstraps)){
 
     # reshape estimates from wide to long
@@ -68,6 +68,6 @@ coef.OaxacaBlinderDecomp <- function(x, ci = FALSE) {
     bs_varlevel = merge(estimates, x$bootstraps$varlevel)
     return(bs_varlevel)
   }
-  
+
   estimates
 }

--- a/R/oaxaca.R
+++ b/R/oaxaca.R
@@ -33,7 +33,7 @@ modify_group_var_to_dummy = function(data, formula){
   })
 
   # modify group var such that group0 (reference) is the group that has a higher dep_var avg
-  dep_var_avgs = aggregate(data[[dep_var]], list(gr=data[[group_var]]), FUN=mean, na.rm=TRUE) 
+  dep_var_avgs = aggregate(data[[dep_var]], list(gr=data[[group_var]]), FUN=mean, na.rm=TRUE)
   dep_var_avgs = dep_var_avgs[order(dep_var_avgs$x, decreasing = TRUE), ]
 
   group1 = dep_var_avgs$gr[1] # higher dep_var avg
@@ -44,7 +44,7 @@ modify_group_var_to_dummy = function(data, formula){
 
   # return with levels specification for metainfo
   list(
-    data = data, 
+    data = data,
     group_levels = c(group1, group2)
   )
 
@@ -80,7 +80,7 @@ fit_models <- function(formula, data) {
 
   # construct formulas
   fml_reg <- paste(fml_comp$dep_var, "~", fml_comp$indep_var)
-  
+
   # currently; pooled reg without group ind as suggested by Neumark (1988)
   fml_reg_pooled_neumark1988 <- paste(fml_comp$dep_var, "~", fml_comp$indep_var)
   fml_reg_pooled_jann2008 <- paste(fml_comp$dep_var, "~", fml_comp$indep_var, "+", fml_comp$group_var)
@@ -96,8 +96,8 @@ fit_models <- function(formula, data) {
   mod_pooled_jann2008 = lm(fml_reg_pooled_jann2008, data=data)
 
   return(list(
-    mod_a = mod_a, 
-    mod_b = mod_b, 
+    mod_a = mod_a,
+    mod_b = mod_b,
     mod_pooled_neumark1988 = mod_pooled_neumark1988,
     mod_pooled_jann2008 = mod_pooled_jann2008
   ))
@@ -108,9 +108,9 @@ extract_betas_EX = function(mod, baseline_invariant){
   modmat = model.matrix(mod)
   betas = coef(mod)
 
-  # if baseline variant; 
+  # if baseline variant;
   # identify factor variables and associated dummy indicators
-  # apply gardeazabal2004 ommitted baseline correction per set of dummy variables 
+  # apply gardeazabal2004 ommitted baseline correction per set of dummy variables
   if (baseline_invariant){
     # identify factor terms
     factor_variables = names(attr(modmat, "contrasts"))
@@ -144,7 +144,7 @@ extract_betas_EX = function(mod, baseline_invariant){
   EX = apply(modmat, mean, MARGIN = 2)
 
   return(list(
-    betas=betas, 
+    betas=betas,
     EX=EX
   ))
 }
@@ -255,8 +255,8 @@ get_bootstrap_ci = function(formula, data, n_bootstraps, type, pooled, baseline_
       lapply(varlevel_coef_names, function(coefname){
           quantile(sapply(varlevel_list, `[`, coefname, cftype), probs = conf_probs)
         }) |> setNames(varlevel_coef_names)
-      }) |> 
-      setNames(coef_types) |> 
+      }) |>
+      setNames(coef_types) |>
       lapply(rbind_list)
 
     CI_varlevel = lapply(coef_types, function(cf_type){
@@ -266,11 +266,11 @@ get_bootstrap_ci = function(formula, data, n_bootstraps, type, pooled, baseline_
         x["term"] = rownames(x)
         rownames(x) = NULL
         x[c(3,4, 1, 2)]
-      }) |> 
+      }) |>
       rbind_list()
 
       return(list(
-        overall=CI_overall, 
+        overall=CI_overall,
         varlevel=CI_varlevel
       ))
 }
@@ -331,8 +331,8 @@ OaxacaBlinderDecomp <- function(formula, data, type = "twofold", pooled = "neuma
     type = type,
     group_levels = gvar_to_num$group_levels,
     formula = deparse(formula),
-    formula_components = parse_formula(formula), 
-    dataset_name = dataset_name, 
+    formula_components = parse_formula(formula),
+    dataset_name = dataset_name,
     data = input_data
   )
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -52,14 +52,14 @@ dplyr::glimpse(chicago_long)
 - The formula interface is similar to the `oaxaca` package: it should be specified as `dependent_var ~ x_var1 + x_var1 + ... + x_varK | group_var`.
 - OaxacaBlinder is capable of correcting for the ommitted baseline bias for multipe sets of factor variables with the `baseline_invariant=TRUE`
 - The `pooled` argument sets what reference $\beta_R$:
-  - `neumark`: The parameters of a model **excluding** the group variable 
-  - `jann`: The parameters of a model **including** the group variable 
+  - `neumark`: The parameters of a model **excluding** the group variable
+  - `jann`: The parameters of a model **including** the group variable
 
 ```{r}
 twofold = OaxacaBlinderDecomp(
-  formula = real_wage ~ age + education | female, 
-  data = chicago_long, 
-  type = "twofold", 
+  formula = real_wage ~ age + education | female,
+  data = chicago_long,
+  type = "twofold",
   baseline_invariant = TRUE,
   n_bootstraps = 100
 )
@@ -82,7 +82,7 @@ coef(twofold, ci=TRUE)
 
 ```{r}
 threefold = OaxacaBlinderDecomp(
-  real_wage ~ age + education | female, chicago_long, 
+  real_wage ~ age + education | female, chicago_long,
   type = "twofold",
   pooled = "jann",
   baseline_invariant = TRUE

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 This is an R implementation of `OaxacaBlinder` decomposition that comes
 with
 
--   correction for dummy encoding baseline with multiple factors
--   more convenient output formatting
+- correction for dummy encoding baseline with multiple factors
+- more convenient output formatting
 
 Please also check the stable `oaxaca` package on CRAN.
 
@@ -46,24 +46,22 @@ dplyr::glimpse(chicago_long)
 
 ### Twofold decomposition
 
--   The formula interface is similar to the `oaxaca` package: it should
-    be specified as
-    `dependent_var ~ x_var1 + x_var1 + ... + x_varK | group_var`.
--   OaxacaBlinder is capable of correcting for the ommitted baseline
-    bias for multipe sets of factor variables with the
-    `baseline_invariant=TRUE`
--   The `pooled` argument sets what reference
-    ![\\beta_R](https://latex.codecogs.com/png.image?%5Cdpi%7B110%7D&space;%5Cbg_white&space;%5Cbeta_R "\beta_R"):
-    -   `neumark`: The parameters of a model **excluding** the group
-        variable
-    -   `jann`: The parameters of a model **including** the group
-        variable
+- The formula interface is similar to the `oaxaca` package: it should be
+  specified as
+  `dependent_var ~ x_var1 + x_var1 + ... + x_varK | group_var`.
+- OaxacaBlinder is capable of correcting for the ommitted baseline bias
+  for multipe sets of factor variables with the
+  `baseline_invariant=TRUE`
+- The `pooled` argument sets what reference $\beta_R$:
+  - `neumark`: The parameters of a model **excluding** the group
+    variable
+  - `jann`: The parameters of a model **including** the group variable
 
 ``` r
 twofold = OaxacaBlinderDecomp(
-  formula = real_wage ~ age + education | female, 
-  data = chicago_long, 
-  type = "twofold", 
+  formula = real_wage ~ age + education | female,
+  data = chicago_long,
+  type = "twofold",
   baseline_invariant = TRUE,
   n_bootstraps = 100
 )
@@ -82,10 +80,10 @@ summary(twofold)
 #> Gap: 3.83
 #> % Diff: 21.88%
 #>               coefficient   % of gap      2.5%     97.5%
-#> explained           -0.53     -13.9% -1.287976 0.4081822
-#> unexplained          4.37     113.9%  3.316634 5.3718167
-#> unexplained_a        1.89      49.2%  1.416425 2.3051504
-#> unexplained_b        2.48      64.6%  1.875524 3.1708094
+#> explained           -0.53     -13.9% -1.306213 0.1681933
+#> unexplained          4.37     113.9%  3.232576 5.5662780
+#> unexplained_a        1.89      49.2%  1.402721 2.5663579
+#> unexplained_b        2.48      64.6%  1.777999 3.1122698
 ```
 
 In addition, coefficients can be extracted vor the variable-level
@@ -107,42 +105,42 @@ Or with bootstrapped confidence intervals for variable level results
 
 ``` r
 coef(twofold, ci=TRUE)
-#>        coef_type                  term  coefficient         2.5%      97.5%
-#> 1      explained           (Intercept)  0.000000000  0.000000000  0.0000000
-#> 2      explained                   age  0.220418162 -0.070889639  0.5171608
-#> 3      explained    education.baseline -0.260197078 -0.677242534  0.1852713
-#> 4      explained      educationcollege -0.009283372 -0.104119347  0.1468720
-#> 5      explained  educationhigh.school -0.107295348 -0.397573363  0.1676307
-#> 6      explained         educationLTHS -0.560862567 -1.131221103 -0.0726498
-#> 7      explained educationsome.college  0.184695669  0.004930454  0.5707748
-#> 8    unexplained           (Intercept)  5.008365163  1.414680056  8.5979229
-#> 9    unexplained                   age  1.078221143 -2.331653258  3.8861475
-#> 10   unexplained    education.baseline  0.352517873 -0.166461236  0.7531078
-#> 11   unexplained      educationcollege  0.011424394 -0.422795950  0.6447075
-#> 12   unexplained  educationhigh.school -0.521244454 -1.376838726  0.6384746
-#> 13   unexplained         educationLTHS -1.155977097 -1.932396932 -0.4684353
-#> 14   unexplained educationsome.college -0.406446395 -1.278282713  0.3626670
-#> 15 unexplained_a           (Intercept)  2.618886538  0.865151387  4.9089987
-#> 16 unexplained_a                   age  0.316402205 -1.570904358  1.6860752
-#> 17 unexplained_a    education.baseline  0.167504793 -0.048997150  0.3425648
-#> 18 unexplained_a      educationcollege -0.019353236 -0.285437460  0.2632378
-#> 19 unexplained_a  educationhigh.school -0.352139226 -0.925407077  0.2120744
-#> 20 unexplained_a         educationLTHS -0.687681871 -1.208045459 -0.2926611
-#> 21 unexplained_a educationsome.college -0.155247041 -0.676757641  0.2215733
-#> 22 unexplained_b           (Intercept)  2.389478624  0.276892212  3.9929385
-#> 23 unexplained_b                   age  0.761818938 -0.992235378  2.4541288
-#> 24 unexplained_b    education.baseline  0.185013080 -0.120768443  0.4154985
-#> 25 unexplained_b      educationcollege  0.030777630 -0.265497408  0.3612030
-#> 26 unexplained_b  educationhigh.school -0.169105228 -0.649993160  0.4049627
-#> 27 unexplained_b         educationLTHS -0.468295226 -0.858761798 -0.1758042
-#> 28 unexplained_b educationsome.college -0.251199354 -0.738113693  0.2083489
+#>        coef_type                  term  coefficient         2.5%       97.5%
+#> 1      explained           (Intercept)  0.000000000  0.000000000  0.00000000
+#> 2      explained                   age  0.220418162 -0.003446369  0.53534373
+#> 3      explained    education.baseline -0.260197078 -0.657812690  0.06859416
+#> 4      explained      educationcollege -0.009283372 -0.151655711  0.12650843
+#> 5      explained  educationhigh.school -0.107295348 -0.403230839  0.34095018
+#> 6      explained         educationLTHS -0.560862567 -1.190555209 -0.06628040
+#> 7      explained educationsome.college  0.184695669  0.008586773  0.41180056
+#> 8    unexplained           (Intercept)  5.008365163  1.300805150  8.41320062
+#> 9    unexplained                   age  1.078221143 -1.846739705  4.19573495
+#> 10   unexplained    education.baseline  0.352517873 -0.133223881  0.75388814
+#> 11   unexplained      educationcollege  0.011424394 -0.547359476  0.46466839
+#> 12   unexplained  educationhigh.school -0.521244454 -1.676171714  0.55148598
+#> 13   unexplained         educationLTHS -1.155977097 -1.919934983 -0.29237190
+#> 14   unexplained educationsome.college -0.406446395 -1.243927239  0.48374409
+#> 15 unexplained_a           (Intercept)  2.618886538  0.556656099  4.71643644
+#> 16 unexplained_a                   age  0.316402205 -1.059082761  1.90174874
+#> 17 unexplained_a    education.baseline  0.167504793 -0.044985535  0.36371764
+#> 18 unexplained_a      educationcollege -0.019353236 -0.259729988  0.22277605
+#> 19 unexplained_a  educationhigh.school -0.352139226 -1.054489794  0.18717027
+#> 20 unexplained_a         educationLTHS -0.687681871 -1.176104919 -0.22955356
+#> 21 unexplained_a educationsome.college -0.155247041 -0.624632761  0.26228669
+#> 22 unexplained_b           (Intercept)  2.389478624  0.488537938  4.54667043
+#> 23 unexplained_b                   age  0.761818938 -0.827969222  2.56148546
+#> 24 unexplained_b    education.baseline  0.185013080 -0.097748156  0.39335298
+#> 25 unexplained_b      educationcollege  0.030777630 -0.303367434  0.28215788
+#> 26 unexplained_b  educationhigh.school -0.169105228 -0.731720008  0.36530685
+#> 27 unexplained_b         educationLTHS -0.468295226 -0.800785060 -0.03573617
+#> 28 unexplained_b educationsome.college -0.251199354 -0.735602991  0.24180657
 ```
 
 ### Threefold decomposition
 
 ``` r
 threefold = OaxacaBlinderDecomp(
-  real_wage ~ age + education | female, chicago_long, 
+  real_wage ~ age + education | female, chicago_long,
   type = "twofold",
   pooled = "jann",
   baseline_invariant = TRUE


### PR DESCRIPTION
This one just removes whitespace at end of lines (since otherwise RStudio auto-cleans them, creating a bunch of new changes to clutter up diffs).

The only other change should be that `README.md` is re-rendered, which (aside from cleaning up some strange URL in a formula?) results in new bootstrapped standard errors since they were sampled differently this time.  I guess it might be nice eventually to set the seed so that they're deterministic in contexts like these?  Seems like a task better left for later though...

Anyway of course let me know if anything looks amiss with this one.