### PR TITLE
Add bootstrapped standard errors

### DIFF
--- a/R/oaxaca.R
+++ b/R/oaxaca.R
@@ -244,7 +244,11 @@ get_bootstrap_ci = function(formula, data, n_bootstraps, type, pooled, baseline_
 
     CI_overall = do.call(rbind, {
       lapply(coef_types, function(coeftype){
-        quantile(sapply(overall_level_list, `[[`, coeftype), probs = conf_probs)
+        coeftype_estimates <- sapply(overall_level_list, `[[`, coeftype)
+        c(
+          se = sd(coeftype_estimates, na.rm = TRUE),
+          quantile(coeftype_estimates, probs = conf_probs)
+        )
       }) |> setNames(coef_types)
     })
 

--- a/R/oaxaca.R
+++ b/R/oaxaca.R
@@ -244,10 +244,10 @@ get_bootstrap_ci = function(formula, data, n_bootstraps, type, pooled, baseline_
 
     CI_overall = do.call(rbind, {
       lapply(coef_types, function(coeftype){
-        coeftype_estimates <- sapply(overall_level_list, `[[`, coeftype)
+        estimates <- sapply(overall_level_list, `[[`, coeftype)
         c(
-          se = sd(coeftype_estimates, na.rm = TRUE),
-          quantile(coeftype_estimates, probs = conf_probs)
+          se = sd(estimates, na.rm = TRUE),
+          quantile(estimates, probs = conf_probs)
         )
       }) |> setNames(coef_types)
     })

--- a/R/oaxaca.R
+++ b/R/oaxaca.R
@@ -257,7 +257,11 @@ get_bootstrap_ci = function(formula, data, n_bootstraps, type, pooled, baseline_
 
     CI_varlevel = lapply(coef_types, function(cftype){
       lapply(varlevel_coef_names, function(coefname){
-          quantile(sapply(varlevel_list, `[`, coefname, cftype), probs = conf_probs)
+        estimates <- sapply(varlevel_list, `[`, coefname, cftype)
+          c(
+            se = sd(estimates, na.rm = TRUE),
+            quantile(estimates, probs = conf_probs)
+          )
         }) |> setNames(varlevel_coef_names)
       }) |>
       setNames(coef_types) |>
@@ -269,7 +273,7 @@ get_bootstrap_ci = function(formula, data, n_bootstraps, type, pooled, baseline_
         x["coef_type"] = cf_type
         x["term"] = rownames(x)
         rownames(x) = NULL
-        x[c(3,4, 1, 2)]
+        x[c(4, 5, 1, 2, 3)]
       }) |>
       rbind_list()
 


### PR DESCRIPTION
A small change to include bootstrapped standard errors along with the CIs.  Of course this adds a column to `$bootstraps` but seems to be handled fine (well, as fine as it was without SEs) by the generics.