### PR TITLE
Calculate gaps using model frames

### DIFF
--- a/R/oaxaca.R
+++ b/R/oaxaca.R
@@ -50,13 +50,11 @@ modify_group_var_to_dummy = function(data, formula){
 
 }
 
-calculate_gap <- function(formula, data) {
+calculate_gap <- function(formula, data_a, data_b) {
   fml_comp <- parse_formula(formula)
 
-  idx <- data[[fml_comp$group_var]] == 0
-
-  EY_a <- mean(data[idx, ][[fml_comp$dep_var]], na.rm = TRUE)
-  EY_b <- mean(data[!idx, ][[fml_comp$dep_var]], na.rm = TRUE)
+  EY_a <- mean(data_a[[fml_comp$dep_var]], na.rm = TRUE)
+  EY_b <- mean(data_b[[fml_comp$dep_var]], na.rm = TRUE)
 
   gap <- EY_a - EY_b
   pct_gap <- gap / EY_a
@@ -326,7 +324,11 @@ OaxacaBlinderDecomp <- function(formula, data, type = "twofold", pooled = "neuma
 
 
   # collect descriptives
-  results$gaps <- calculate_gap(formula, data)
+  results$gaps <- calculate_gap(
+    formula,
+    model.frame(fitted_models$mod_a),
+    model.frame(fitted_models$mod_b)
+  )
   results$meta <- list(
     type = type,
     group_levels = gvar_to_num$group_levels,


### PR DESCRIPTION
Should fix #6.  Hard to test as always, but here's a minimal-yet-still-clunky one:

``` r
library(OaxacaBlinder)

clna <- 
  chicago_long |>
  dplyr::mutate(educ2 = dplyr::na_if(education, "LTHS"))

twofold <-
  OaxacaBlinderDecomp(
    formula = real_wage ~ educ2 | female, 
    data = clna, 
    type = "twofold", 
    baseline_invariant = TRUE,
    n_bootstraps = 30
  )

clna |>
  dplyr::filter(!is.na(educ2)) |>
  dplyr::group_by(female) |>
  dplyr::summarize(mean = mean(real_wage, na.rm = TRUE)) |>
  dplyr::mutate(diff = dplyr::lag(mean) - mean) |>
  purrr::pluck("diff", 2) |>
  identical(twofold$gaps$gap)
#> [1] TRUE
```

<sup>Created on 2024-03-15 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>