### PR TITLE
Update GHA for manual run

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,10 +1,7 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  pull_request:
-    branches:
-      - "dev"
-      - "master"
+  workflow_dispatch:
   push:
     paths: ["**.[rR]", "**.[qrR]md", "**.[rR]markdown", "**.[rR]nw", "**.[rR]profile"]
 


### PR DESCRIPTION
This one just brings the commit from master which (I think!) activates the manual GHA into the dev branch.