### PR TITLE
Add p-values

### DIFF
--- a/R/oaxaca.R
+++ b/R/oaxaca.R
@@ -456,6 +456,14 @@ extract_bootstrap_estimates <- function(runs,
   bs_estimates
 }
 
+calculate_pval <- function(data, null_val) {
+  # Adapted from https://stats.stackexchange.com/a/83038
+  p1 <- sum(data > null_val) / length(data)
+  p2 <- sum(data < null_val) / length(data)
+  p <- min(p1, p2) * 2
+  p
+}
+
 summarize_bootstraps <- function(bs_estimates, conf_probs) {
   # term_type, term, summary type in columns; 1 df per term_type
   bs_summaries_list <-
@@ -464,9 +472,11 @@ summarize_bootstraps <- function(bs_estimates, conf_probs) {
       function(term_type) {
         se <- lapply(bs_estimates[[term_type]], sd, na.rm = TRUE)
         ci <- lapply(bs_estimates[[term_type]], quantile, conf_probs)
+        pval <- lapply(bs_estimates[[term_type]], calculate_pval, 0)
         summ <- data.frame(
           se = do.call(rbind, se),
           do.call(rbind, ci),
+          pval = do.call(rbind, pval),
           check.names = FALSE
         )
         summ <-

--- a/tests/testthat/_snaps/oaxaca.md
+++ b/tests/testthat/_snaps/oaxaca.md
@@ -16,10 +16,10 @@
       
       Gap: 0.21
       % Diff: 7.62%
-                   coefficient   % of gap          se        2.5%        97.5%
-      endowments         -0.02     -10.5% 0.020692651 -0.05943318 -0.000469790
-      coefficients        0.24     116.8% 0.022550846  0.21480438  0.273919983
-      interaction        -0.01      -6.3% 0.009932174 -0.03398801 -0.004804524
+                   coefficient   % of gap          se        2.5%        97.5% pval
+      endowments         -0.02     -10.5% 0.020692651 -0.05943318 -0.000469790  0.2
+      coefficients        0.24     116.8% 0.022550846  0.21480438  0.273919983  0.0
+      interaction        -0.01      -6.3% 0.009932174 -0.03398801 -0.004804524  0.0
 
 ---
 
@@ -48,72 +48,72 @@
       19  interaction         educationcollege  0.0002097521 0.001701718
       20  interaction     educationhigh.school  0.0004117630 0.001020211
       21  interaction    educationsome.college -0.0024367502 0.004272839
-                  2.5%         97.5%
-      1   0.1676892982  0.5076361160
-      2  -0.2080100134  0.0918145056
-      3  -0.0462741625  0.0006824008
-      4  -0.0045993505  0.0303170117
-      5  -0.0180129791  0.0056651748
-      6  -0.0203106051  0.0300759086
-      7  -0.0240752159  0.0287183945
-      8   0.0000000000  0.0000000000
-      9  -0.0061312589  0.0356309584
-      10 -0.0533409527 -0.0172267929
-      11 -0.0234066642 -0.0077666026
-      12 -0.0085444075  0.0029986197
-      13 -0.0168213031  0.0062207001
-      14  0.0009117397  0.0177683331
-      15  0.0000000000  0.0000000000
-      16 -0.0134980866  0.0004285314
-      17 -0.0165542883  0.0003562039
-      18 -0.0132856154  0.0021842629
-      19 -0.0013819543  0.0033242113
-      20 -0.0017353171  0.0012638658
-      21 -0.0091418736  0.0029662950
+                  2.5%         97.5% pval
+      1   0.1676892982  0.5076361160  0.0
+      2  -0.2080100134  0.0918145056  0.2
+      3  -0.0462741625  0.0006824008  0.2
+      4  -0.0045993505  0.0303170117  0.4
+      5  -0.0180129791  0.0056651748  0.4
+      6  -0.0203106051  0.0300759086  0.8
+      7  -0.0240752159  0.0287183945  0.6
+      8   0.0000000000  0.0000000000  0.0
+      9  -0.0061312589  0.0356309584  0.2
+      10 -0.0533409527 -0.0172267929  0.0
+      11 -0.0234066642 -0.0077666026  0.0
+      12 -0.0085444075  0.0029986197  0.8
+      13 -0.0168213031  0.0062207001  0.6
+      14  0.0009117397  0.0177683331  0.0
+      15  0.0000000000  0.0000000000  0.0
+      16 -0.0134980866  0.0004285314  0.4
+      17 -0.0165542883  0.0003562039  0.2
+      18 -0.0132856154  0.0021842629  0.4
+      19 -0.0013819543  0.0033242113  0.8
+      20 -0.0017353171  0.0012638658  1.0
+      21 -0.0091418736  0.0029662950  0.6
 
 # twofold results with bootstraps haven't changed
 
     Code
       rounded_coefs
     Output
-             coef_type                     term coefficient    se   2.5%  97.5%
-      1      explained              (Intercept)       0.000 0.000  0.000  0.000
-      2      explained                      age       0.012 0.012 -0.006  0.029
-      3      explained       education.baseline      -0.030 0.013 -0.060 -0.023
-      4      explained educationadvanced.degree      -0.011 0.007 -0.025 -0.008
-      5      explained         educationcollege      -0.001 0.004 -0.008  0.003
-      6      explained     educationhigh.school      -0.005 0.007 -0.017  0.006
-      7      explained    educationsome.college       0.005 0.005  0.001  0.014
-      8    unexplained              (Intercept)       0.313 0.112  0.168  0.508
-      9    unexplained                      age      -0.068 0.098 -0.211  0.092
-      10   unexplained       education.baseline      -0.025 0.017 -0.052  0.001
-      11   unexplained educationadvanced.degree       0.005 0.009 -0.003  0.023
-      12   unexplained         educationcollege      -0.006 0.009 -0.016  0.005
-      13   unexplained     educationhigh.school       0.006 0.017 -0.021  0.031
-      14   unexplained    educationsome.college       0.009 0.017 -0.023  0.025
-      15 unexplained_a              (Intercept)       0.035 0.055 -0.039  0.129
-      16 unexplained_a                      age      -0.027 0.045 -0.095  0.046
-      17 unexplained_a       education.baseline      -0.011 0.009 -0.026  0.001
-      18 unexplained_a educationadvanced.degree       0.002 0.004 -0.002  0.010
-      19 unexplained_a         educationcollege      -0.003 0.004 -0.007  0.002
-      20 unexplained_a     educationhigh.school       0.001 0.009 -0.014  0.013
-      21 unexplained_a    educationsome.college       0.004 0.008 -0.014  0.010
-      22 unexplained_b              (Intercept)       0.277 0.059  0.207  0.390
-      23 unexplained_b                      age      -0.040 0.055 -0.117  0.047
-      24 unexplained_b       education.baseline      -0.013 0.008 -0.026  0.000
-      25 unexplained_b educationadvanced.degree       0.003 0.005 -0.002  0.013
-      26 unexplained_b         educationcollege      -0.003 0.005 -0.009  0.003
-      27 unexplained_b     educationhigh.school       0.005 0.008 -0.008  0.018
-      28 unexplained_b    educationsome.college       0.006 0.009 -0.010  0.016
+             coef_type                     term coefficient    se   2.5%  97.5% pval
+      1      explained              (Intercept)       0.000 0.000  0.000  0.000  0.0
+      2      explained                      age       0.012 0.012 -0.006  0.029  0.2
+      3      explained       education.baseline      -0.030 0.013 -0.060 -0.023  0.0
+      4      explained educationadvanced.degree      -0.011 0.007 -0.025 -0.008  0.0
+      5      explained         educationcollege      -0.001 0.004 -0.008  0.003  0.8
+      6      explained     educationhigh.school      -0.005 0.007 -0.017  0.006  0.6
+      7      explained    educationsome.college       0.005 0.005  0.001  0.014  0.0
+      8    unexplained              (Intercept)       0.313 0.112  0.168  0.508  0.0
+      9    unexplained                      age      -0.068 0.098 -0.211  0.092  0.2
+      10   unexplained       education.baseline      -0.025 0.017 -0.052  0.001  0.2
+      11   unexplained educationadvanced.degree       0.005 0.009 -0.003  0.023  0.4
+      12   unexplained         educationcollege      -0.006 0.009 -0.016  0.005  0.4
+      13   unexplained     educationhigh.school       0.006 0.017 -0.021  0.031  0.8
+      14   unexplained    educationsome.college       0.009 0.017 -0.023  0.025  0.6
+      15 unexplained_a              (Intercept)       0.035 0.055 -0.039  0.129  0.2
+      16 unexplained_a                      age      -0.027 0.045 -0.095  0.046  0.2
+      17 unexplained_a       education.baseline      -0.011 0.009 -0.026  0.001  0.2
+      18 unexplained_a educationadvanced.degree       0.002 0.004 -0.002  0.010  0.4
+      19 unexplained_a         educationcollege      -0.003 0.004 -0.007  0.002  0.4
+      20 unexplained_a     educationhigh.school       0.001 0.009 -0.014  0.013  1.0
+      21 unexplained_a    educationsome.college       0.004 0.008 -0.014  0.010  0.6
+      22 unexplained_b              (Intercept)       0.277 0.059  0.207  0.390  0.0
+      23 unexplained_b                      age      -0.040 0.055 -0.117  0.047  0.2
+      24 unexplained_b       education.baseline      -0.013 0.008 -0.026  0.000  0.2
+      25 unexplained_b educationadvanced.degree       0.003 0.005 -0.002  0.013  0.4
+      26 unexplained_b         educationcollege      -0.003 0.005 -0.009  0.003  0.6
+      27 unexplained_b     educationhigh.school       0.005 0.008 -0.008  0.018  0.6
+      28 unexplained_b    educationsome.college       0.006 0.009 -0.010  0.016  0.6
 
 # bootstrapped gaps haven't changed
 
     Code
       obd$bootstraps$gaps
     Output
-                       se       2.5%      97.5%
-      gap     0.023386760 0.15953913 0.23560859
-      pct_gap 0.008383587 0.05962221 0.08679097
-      EY_a    0.028655738 2.66036591 2.74872068
-      EY_b    0.028167210 2.47231616 2.55630572
+                       se       2.5%      97.5% pval
+      gap     0.023386760 0.15953913 0.23560859    0
+      pct_gap 0.008383587 0.05962221 0.08679097    0
+      EY_a    0.028655738 2.66036591 2.74872068    0
+      EY_b    0.028167210 2.47231616 2.55630572    0
 


### PR DESCRIPTION
This is a small change to add 2-tailed p-values to the results alongside the SEs and CIs.  Of course that is a breaking change, but it shouldn't cause too many headaches because it's just an addition to the results.

I couldn't come up with a good test for this since there's nothing against which to compare bootstraps, but I looked at (nearly) all of the distributions in the debugger to make sure that the values in the snapshot tests were correct; so this PR puts a new column in those snapshots.  Note that the test that needed rounding ignores the new p-values, which is probably for the best since otherwise it'd be quite tricky to predict how many values on each side of zero each operating system comes up with.

The p-value calculator itself (which, as I noted in the code, I adapted from https://stats.stackexchange.com/a/83038) takes an argument that can control the null hypothesis, but for now it's always called with 0 (as, I think?, it is when `lm()` and the like calculate their p-values).  If we want to allow users to choose a different p-value (without having to calculate it themselves from the bootstrap distributions, which they can now), we can allow them to pass a new arg to `OaxacaBlinderDecomp()`; but this isn't implemented yet.

Also I think it's worth noting that the p-values this PR computes are true empirical p-values in the bootstrapped distribution (like how the SE estimate is a true SD of the bootstraps).  This is different from the CIs, since the CIs come from `quantile()`, which interpolates the gaps in a distribution, like so:

``` r
quantile(0:10, 0.12345)
#> 12.345% 
#>  1.2345
```

<sup>Created on 2024-05-07 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

That means that in theory (and with few enough bootstrap repetitions), there could be cases where the CI and the p-value "disagree", and the user would have to choose whether to use the empirical version or the smoothed version from `quantile()`.  It seems like it'd be nice to document this, but I wasn't sure where to do that (we don't have much docs about the results yet I don't think?).  Of course another option would be to make the CIs strictly empirical as well, but @sinanpl I don't really have a strong opinion on that.  (My opinion that the p-value and SE *should* be strictly empirical is a bit stronger, though I suppose I could probably be convinced of that too?)

Anyway @sinanpl I've got this in my private branch already so at this stage I'll leave this open if you want to review and/or accept it.  (If it starts to create merge conflicts then I might go ahead and accept it into `dev`.)