### PR TITLE
Add EX results

### DIFF
--- a/R/oaxaca.R
+++ b/R/oaxaca.R
@@ -384,7 +384,7 @@ calculate_coefs <-
       OVERALL_INTER <- sum(terms$interaction)
 
       variable_level_results <-
-        terms[c("endowments", "coefficients", "interaction")]
+        terms[c("endowments", "coefficients", "interaction", "EX_a", "EX_b")]
 
       overall_results <- list(
         endowments = OVERALL_ENDOW,
@@ -408,7 +408,8 @@ calculate_coefs <-
         terms[
           c(
             "explained", "unexplained",
-            "unexplained_a", "unexplained_b"
+            "unexplained_a", "unexplained_b",
+            "EX_a", "EX_b"
           )
         ]
 
@@ -518,7 +519,7 @@ get_bootstraps <- function(formula,
         isTRUE(all.equal(
           sum(
             x$varlevel[!(names(x$varlevel)
-            %in% c("unexplained_a", "unexplained_b"))],
+            %in% c("unexplained_a", "unexplained_b", "EX_a", "EX_b"))],
             na.rm = FALSE
           ),
           x$gaps$gap
@@ -708,7 +709,7 @@ OaxacaBlinderDecomp <-
           sum(
             decomp$results$varlevel[
               !(names(decomp$results$varlevel)
-              %in% c("unexplained_a", "unexplained_b"))
+              %in% c("unexplained_a", "unexplained_b", "EX_a", "EX_b"))
             ],
             na.rm = TRUE
           ),

--- a/tests/testthat/test-oaxaca.R
+++ b/tests/testthat/test-oaxaca.R
@@ -11,7 +11,7 @@ test_that("baseline-adjusted-IV threefold results match Stata", {
       type = "threefold"
     )
   # Match and sort rownames
-  obd_ests <- obd$varlevel
+  obd_ests <- obd$varlevel[c("endowments", "coefficients", "interaction")]
   rownames(obd_ests) <- gsub("education", "", rownames(obd_ests))
   rownames(obd_ests) <-
     gsub(".baseline", baseline_rowname, rownames(obd_ests))
@@ -159,6 +159,7 @@ testthat::test_that("threefold matches other calcs", {
       data = chicago,
       type = "threefold"
     )
+  obd3$varlevel <- obd3$varlevel[c("endowments", "coefficients", "interaction")]
   obd_3f_terms <-
     obd3$varlevel[order(obd3$varlevel[, 1]), ]
 
@@ -183,7 +184,7 @@ testthat::test_that("threefold matches other calcs", {
 
   # Confirm function results match ----
   testthat::expect_equal(
-    obd_3f_terms,
+    obd_3f_terms[c("endowments", "coefficients", "interaction")],
     oax_3f_terms
   )
 })
@@ -237,7 +238,7 @@ testthat::test_that("neumark twofold matches manual calcs", {
     obd2$varlevel[order(obd2$varlevel[, 1]), ]
 
   testthat::expect_equal(
-    obd_2f_terms,
+    obd_2f_terms[c("explained", "unexplained", "unexplained_a", "unexplained_b")],
     manual_2f_terms
   )
 })
@@ -421,7 +422,7 @@ test_that("0-variance dummy IV results match Stata", {
   stata_obd_ests <- stata_obd[order(rownames(stata_obd)), ]
 
   testthat::expect_equal(
-    obd_ests,
+    obd_ests[c("endowments", "coefficients", "interaction")],
     stata_obd_ests
   )
 })
@@ -440,7 +441,7 @@ test_that("0-variance categorical IV results match Stata", {
       data = chicago_long_mod,
       type = "threefold"
     )
-  obd_ests <- obd$varlevel
+  obd_ests <- obd$varlevel[c("endowments", "coefficients", "interaction")]
   rownames(obd_ests) <- gsub("education", "", rownames(obd_ests))
   rownames(obd_ests) <- gsub("\\.", "_", rownames(obd_ests))
   obd_ests <- obd_ests[order(rownames(obd_ests)), ]
@@ -471,7 +472,7 @@ test_that("0-variance baseline-adjusted IV results match Stata", {
       type = "threefold"
     )
   # Match and sort rownames
-  obd_ests <- obd$varlevel
+  obd_ests <- obd$varlevel[c("endowments", "coefficients", "interaction")]
   rownames(obd_ests) <- gsub("education", "", rownames(obd_ests))
   rownames(obd_ests) <-
     gsub(".baseline", baseline_rowname, rownames(obd_ests))

--- a/tests/testthat/test-oaxaca.R
+++ b/tests/testthat/test-oaxaca.R
@@ -540,6 +540,11 @@ test_that("bootstrapped gaps haven't changed", {
 })
 
 test_that("EXs are correct", {
+  # Hack to make baseline names the same
+  chicago_long$education[chicago_long$education == "LTHS"] <- ".baseline"
+  chicago_long$education <-
+    as.factor(chicago_long$education) |>
+    relevel(ref = ".baseline") # force baseline in spite of sort order
   set.seed(1973)
   threefold <- OaxacaBlinderDecomp(
     formula = ln_real_wage ~ age + education | female,

--- a/tests/testthat/test-oaxaca.R
+++ b/tests/testthat/test-oaxaca.R
@@ -564,7 +564,15 @@ test_that("EXs are correct", {
   EX_a_manual <- c(colMeans(modmat_a), `(Intercept)` = 1)
   EX_b_manual <- c(colMeans(modmat_b), `(Intercept)` = 1)
 
-  # Compare
-  testthat::expect_equal(threefold$varlevel$EX_a, EX_a_manual)
-  testthat::expect_equal(threefold$varlevel$EX_b, EX_b_manual)
+  EX_a_auto <- threefold$varlevel$EX_a |> setNames(rownames(threefold$varlevel))
+  EX_b_auto <- threefold$varlevel$EX_b |> setNames(rownames(threefold$varlevel))
+
+  # Use numeric sort order
+  EX_a_manual <- EX_a_manual[order(EX_a_manual)]
+  EX_b_manual <- EX_b_manual[order(EX_b_manual)]
+  EX_a_auto <- EX_a_auto[order(EX_a_auto)]
+  EX_b_auto <- EX_b_auto[order(EX_b_auto)]
+
+  testthat::expect_equal(EX_a_auto, EX_a_manual)
+  testthat::expect_equal(EX_b_auto, EX_b_manual)
 })

--- a/tests/testthat/test-oaxaca.R
+++ b/tests/testthat/test-oaxaca.R
@@ -556,10 +556,10 @@ test_that("EXs are correct", {
     model.matrix(ln_real_wage ~ age + education + 0, data_a)
   modmat_b <-
     model.matrix(ln_real_wage ~ age + education + 0, data_b)
-  EX_a <- colMeans(modmat_a)
-  EX_b <- colMeans(modmat_b)
+  EX_a_manual <- c(colMeans(modmat_a), `(Intercept)` = 1)
+  EX_b_manual <- c(colMeans(modmat_b), `(Intercept)` = 1)
 
   # Compare
-  testthat::expect_equal(threefold$varlevel$EX_a, EX_a)
-  testthat::expect_equal(threefold$varlevel$EX_b, EX_b)
+  testthat::expect_equal(threefold$varlevel$EX_a, EX_a_manual)
+  testthat::expect_equal(threefold$varlevel$EX_b, EX_b_manual)
 })

--- a/tests/testthat/test-oaxaca.R
+++ b/tests/testthat/test-oaxaca.R
@@ -538,3 +538,28 @@ test_that("bootstrapped gaps haven't changed", {
   )
   testthat::expect_snapshot(obd$bootstraps$gaps)
 })
+
+test_that("EXs are correct", {
+  set.seed(1973)
+  threefold <- OaxacaBlinderDecomp(
+    formula = ln_real_wage ~ age + education | female,
+    data = chicago_long,
+    type = "threefold",
+    baseline_invariant = TRUE,
+    n_bootstraps = 10
+  )
+
+  # Calc EXs manually
+  data_a <- chicago_long[chicago_long$female == 0, ]
+  data_b <- chicago_long[chicago_long$female == 1, ]
+  modmat_a <-
+    model.matrix(ln_real_wage ~ age + education + 0, data_a)
+  modmat_b <-
+    model.matrix(ln_real_wage ~ age + education + 0, data_b)
+  EX_a <- colMeans(modmat_a)
+  EX_b <- colMeans(modmat_b)
+
+  # Compare
+  testthat::expect_equal(threefold$varlevel$EX_a, EX_a)
+  testthat::expect_equal(threefold$varlevel$EX_b, EX_b)
+})


### PR DESCRIPTION
This PR adds `EX_a` and `EX_b` columns to the `varlevel` data frame in the results.  (I see that Hlavac's `oaxaca` package stores these in `$x`.)  The change itself is small, but it broke a bunch of old tests where I had lazily used `$varlevel` without specifying any columns, so most of this PR is specifying the columns in those tests (all of which now pass for me).  This PR also adds a new test to compare the new columns against the same things calculated manually.

Of course this is another soft-breaking change since it adds two columns to the results, but it shouldn't change or remove anything that's already there.

I've updated #49 and #50 to specify `$varlevel` columns in their tests; after that change, merging this PR into a branch with those PRs in it will create a trivial merge conflict since both PRs add tests to the end of `test-oaxaca.R`.  @sinanpl, as with #52, I don't think this is blocking anything yet, so I'll leave it open for you to review and/or accept.  Meantime I've got it merged into https://github.com/davidskalinder/OaxacaBlinder-development/tree/dev_w_viewpoint_arg, so I'll continue to use that for testing.